### PR TITLE
Use rsync instead of deleting all data and re-copying all data

### DIFF
--- a/update_data.sh
+++ b/update_data.sh
@@ -11,9 +11,7 @@ function wait_for_change {
 
 while wait_for_change; do
   sleep 2
-  rm -rf www/data/json
-  rm -rf www/addr
-  cp -r $DATADIR/json www/data/json
+  rsync -rlt --delete $DATADIR/json www/data/
   /usr/bin/python ./bsq_json.py &
 done
 


### PR DESCRIPTION
We only need an incremental update of new data and to delete old TX that could disappear from a re-org, no need to re-copy all data every time