### PR TITLE
Watch JSON folder for initial seednode sync detection

### DIFF
--- a/bsq-explorer
+++ b/bsq-explorer
@@ -17,7 +17,7 @@ while true
 do
     if [ ! -e "${BSQ_BLOCKS_FILE}" ];then
         echo "Waiting for BSQ blocks file ${BSQ_BLOCKS_FILE} to be created!"
-        inotifywait -qq -r -e modify,move,create,delete "${BSQ_BLOCKS_FILE}"
+        inotifywait -qq -r -e modify,move,create,delete "${BISQ_JSON_DIR}"
         continue
     fi
     # sync


### PR DESCRIPTION
`Couldn't watch /bisq/bisq-seednode/btc_mainnet/db/json/all/blocks.json: No such file or directory`