### PR TITLE
Add a HTML page explaining explorer.bisq.network is deprecated

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# 🚨 explorer.bisq.network has been decentralized ! 🚨
+
+## Please use one of the following new BSQ explorers instead:
+
+* [https://bsq.ninja](https://bsq.ninja) (operated by @wiz)
+* [https://bsq.sqrrm.net](https://bsq.sqrrm.net) (operated by @sqrrm)
+* [https://bsq.bisq.services](https://bsq.bisq.services) (operated by @devinbileck)
+* [https://bsq.vante.me](https://bsq.vante.me) (operated by @mrosseel)
+* [https://bsq.emzy.de](https://bsq.emzy.de) (operated by @emzy)
+* [https://bsq.bisq.cc](https://bsq.bisq.cc) (operated by @m52go)
+
+## Bisq v1.2.5 will automatically select one at random for you, please upgrade :)


### PR DESCRIPTION
Implements the final phase of https://github.com/bisq-network/proposals/issues/143
Preview: https://wiz.github.io/bisq-explorer/
After merging, need to enable GitHub pages and repoint DNS for explorer.bisq.network 
<img width="751" alt="Screen Shot 2020-01-10 at 8 56 48" src="https://user-images.githubusercontent.com/232186/72115707-55223f80-338b-11ea-84b1-74e4bfc8ab8b.png">
<img width="665" alt="Screen Shot 2020-01-10 at 9 04 32" src="https://user-images.githubusercontent.com/232186/72115714-57849980-338b-11ea-9820-14e4ba9f9bf9.png">
