### PR TITLE
Redirect users to a random BSQ explorer using HTML/JS

### DIFF
--- a/docs/API.html
+++ b/docs/API.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+    <title>BSQ Explorer</title>
+    <script src="random-redirect.js"></script>
+</head>
+<body>
+Redirecting you to a random BSQ explorer...
+<noscript>
+Javascript is required for the BSQ explorer redirect.
+</noscript>
+</body>
+</html>

--- a/docs/Address.html
+++ b/docs/Address.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+    <title>BSQ Explorer</title>
+    <script src="random-redirect.js"></script>
+</head>
+<body>
+Redirecting you to a random BSQ explorer...
+<noscript>
+Javascript is required for the BSQ explorer redirect.
+</noscript>
+</body>
+</html>

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,3 +10,5 @@
 * [https://bsq.bisq.cc](https://bsq.bisq.cc) (operated by @m52go)
 
 ## Bisq v1.2.5 will automatically select one at random for you, please upgrade :)
+
+This folder only contains HTML/JS redirects for old Bisq apps which use the https://explorer.bisq.network URL

--- a/docs/Search.html
+++ b/docs/Search.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+    <title>BSQ Explorer</title>
+    <script src="random-redirect.js"></script>
+</head>
+<body>
+Redirecting you to a random BSQ explorer...
+<noscript>
+Javascript is required for the BSQ explorer redirect.
+</noscript>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+    <title>BSQ Explorer</title>
+    <script src="random-redirect.js"></script>
+</head>
+<body>
+Redirecting you to a random BSQ explorer...
+<noscript>
+Javascript is required for the BSQ explorer redirect.
+</noscript>
+</body>
+</html>

--- a/docs/random-redirect.js
+++ b/docs/random-redirect.js
@@ -1,0 +1,10 @@
+var explorers = [
+    "https://bsq.ninja",
+    "https://bsq.sqrrm.net",
+    "https://bsq.bisq.services",
+    "https://bsq.vante.me",
+    "https://bsq.emzy.de",
+    "https://bsq.bisq.cc",
+];
+var explorer = explorers[Math.floor(Math.random() * 1000) % explorers.length];
+document.location.href = explorer + document.location.pathname + document.location.search;

--- a/docs/stats.html
+++ b/docs/stats.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+    <title>BSQ Explorer</title>
+    <script src="random-redirect.js"></script>
+</head>
+<body>
+Redirecting you to a random BSQ explorer...
+<noscript>
+Javascript is required for the BSQ explorer redirect.
+</noscript>
+</body>
+</html>

--- a/docs/tx.html
+++ b/docs/tx.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+    <title>BSQ Explorer</title>
+    <script src="random-redirect.js"></script>
+</head>
+<body>
+Redirecting you to a random BSQ explorer...
+<noscript>
+Javascript is required for the BSQ explorer redirect.
+</noscript>
+</body>
+</html>

--- a/docs/txo.html
+++ b/docs/txo.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+    <title>BSQ Explorer</title>
+    <script src="random-redirect.js"></script>
+</head>
+<body>
+Redirecting you to a random BSQ explorer...
+<noscript>
+Javascript is required for the BSQ explorer redirect.
+</noscript>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a random redirect from https://explorer.bisq.network/<args> to one of our 6 explorers with the same args. Example redirect previews from my local repo:

https://github.bsq.ninja/tx.html?tx=8a51c743e9643920296b4960336ef3af32436f8a5d39ad36158448a77889b5b7

https://github.bsq.ninja/Address.html?addr=12aCWhzYJXL3CeoaZ3owFcRCDkYY4q7qdQ