### PR TITLE
Increase delay after notifywait to complete JSON dump before indexing

### DIFF
--- a/bsq-explorer
+++ b/bsq-explorer
@@ -34,5 +34,5 @@ do
     echo "Detected BSQ transaction data update from Bisq seednode"
 
     # allow time for seednode to complete JSON data dump
-    sleep 10
+    sleep 30
 done


### PR DESCRIPTION
New transactions are currently delayed by 1 block - this increased delay should allow for Bisq to complete its JSON data dump before the bsq-explorer index script is run, so new TX can appear within 1 minute of being confirmed