### PR TITLE
As part of shutting down half the legacy BSQ explorers, update redirect

### DIFF
--- a/docs/random-redirect.js
+++ b/docs/random-redirect.js
@@ -1,10 +1,7 @@
 var explorers = [
     "https://bsq.ninja",
-    "https://bsq.sqrrm.net",
-    "https://bsq.bisq.services",
-    "https://bsq.vante.me",
     "https://bsq.emzy.de",
-    "https://bsq.bisq.cc",
+    "https://bsq.bisq.services"
 ];
 var explorer = explorers[Math.floor(Math.random() * 1000) % explorers.length];
 document.location.href = explorer + document.location.pathname + document.location.search;


### PR DESCRIPTION
Currently the retired hostname https://explorer.bisq.network/ redirects to 1 of 6 explorers. Since we are now shutting down 3 of them, this removes those 3 from the list.